### PR TITLE
Fix compatibility metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,18 +23,19 @@
   "source": "https://github.com/n1tr0g/golja-ioncubeloader.git",
   "summary": "Ioncube loader support for php",
   "operatingsystem_support": [
-        "RedHat",
-        "Debian",
-        "Ubuntu"
-    ],
-    "puppet_version": [
-        "2.7",
-        "3.0",
-        "3.1",
-        "3.2",
-        "3.3",
-        "3.4"
-    ],
+        {
+          "operatingsystem": "RedHat"
+        },
+        {
+          "operatingsystem": "Debian"
+        },
+        {
+          "operatingsystem": "Ubuntu"
+        }
+  ],
+  "requirements": [
+        { "name": "puppet", "version_requirement": ">=2.7.0 <4.0.0" }
+  ],
   "types": [],
   "version": "0.1.0"
 }


### PR DESCRIPTION
This commit adjusts the operatingsystem and puppet version
compatibility information to express the same information but
function correctly with the Puppet Forge. Apologies for our sparse
documentation. That's getting fixed in the next week.
