### PR TITLE
Change priority

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@ class ioncubeloader(
 
   file { "${php_conf_dir}/${ini_file}":
     ensure  => $ensure,
-    content => ";Managed by puppet\nzend_extension=${install_prefix}/ioncube/${ioncube_loader}\n"
+    content => ";Managed by puppet\n; priority=0\nzend_extension=${install_prefix}/ioncube/${ioncube_loader}\n"
   }
 
   if $ensure == 'present' {


### PR DESCRIPTION
For Debian based operating systems, priority of the config file is included in the source, this allows effective use of phpenmod and friends.
